### PR TITLE
fix/bug fixes for initial release in linux

### DIFF
--- a/apps/nextcloud/docker-compose.yml
+++ b/apps/nextcloud/docker-compose.yml
@@ -41,10 +41,15 @@ services:
       - PGID=1000
       - TZ=Etc/UTC
 
+#     https://github.com/nextcloud/docker
+
       - MYSQL_PASSWORD=$ADMIN_PASS_GLOBAL
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=$ADMIN_USER_GLOBAL
       - MYSQL_HOST=dbnc
+
+      # WebDav file sync will refuse to work because internally we use http inside docker-compose
+      - OVERWRITEPROTOCOL=https
 
 #      - ServerName=$HTTP_SCHEMA://nextcloud.$DOMAINNAME
 #      - NEXTCLOUD_ADMIN_USER=$ADMIN_USER_GLOBAL

--- a/apps/squid_proxy/docker-compose.yml
+++ b/apps/squid_proxy/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - "3128:3128"
     volumes:
-      - ./squid.conf:/etc/squid/squid.conf
+      # ./squid.conf works in osx but not in linux
+      - ${PWD}/apps/squid_proxy/squid.conf:/etc/squid/squid.conf
     restart: always
     networks:
       - web

--- a/apps/vaultwarden/docker-compose.yml
+++ b/apps/vaultwarden/docker-compose.yml
@@ -8,8 +8,10 @@ services:
     volumes:
       - $APP_DATA_DIR/vaultwarden:/data
     environment:
-      - SIGNUPS_ALLOWED=false
-      - WEBSOCKET_ENABLED=true
+      # https://github.com/dani-garcia/vaultwarden/blob/main/.env.template
+      - SIGNUPS_ALLOWED=true
+      - WEBSOCKET_ENABLED=false
+      - ADMIN_TOKEN=$ADMIN_PASS_GLOBAL
     networks:
       - no_internet
     labels:


### PR DESCRIPTION
- :bug: Fix squid configuration mount to work in Linux
- :bug: Fix nextcloud file sync to allow http communication inside docker-compose
- :bug: fixed initial configuation to allow admin to be created - TODO: disable new sign ups
